### PR TITLE
Set query type to selected default type

### DIFF
--- a/src/TestBench.js
+++ b/src/TestBench.js
@@ -114,6 +114,8 @@ export default class TestBench extends React.Component {
      };
      if (this.state.reconType === 'custom-type' && this.state.reconCustomType !== undefined) {
         query.type = this.state.reconCustomType.id;
+     } else if (this.state.reconType !== 'no-type') {
+        query.type = this.state.reconType;
      }
      if (this.state.reconProperties.length > 0) {
         query.properties = this.state.reconProperties
@@ -141,9 +143,9 @@ export default class TestBench extends React.Component {
     let choices = this.defaultTypes.map(t =>
        <Radio
           name="reconcileType"
-          key={'default-'+t.id}
-          value={'default-'+t.id}
-          checked={current === 'default-'+t.id}
+          key={t.id}
+          value={t.id}
+          checked={current === t.id}
           onChange={this.onReconTypeChange}>
         {t.name}<br /><span className="reconTypeId">{t.id}</span>
       </Radio>


### PR DESCRIPTION
Selecting one of the `defaultTypes` provided by our service does not restrict the reconciliation.

To reproduce:

- In https://reconciliation-api.github.io/testbench/, `Test bench` tab, enter https://lobid.org/gnd/reconcile
- Name: `Twain`
- Type: Select `Körperschaft` / `CorporateBody`
- Click `Reconcile`

The results contain persons and other types, not just corporate bodies.

I'm not sure if my removal of the `default-` string is a good solution, but with this change, it works for me.