### PR TITLE
Tweak suggestions UI in testbench tab

### DIFF
--- a/src/ReconciliationServiceInput.js
+++ b/src/ReconciliationServiceInput.js
@@ -86,7 +86,7 @@ export default class ReconciliationServiceInput extends React.Component {
         <Form horizontal>
           <FormGroup controlId="endpointField" validationState={this.getValidationState()}>
             <Col componentClass={ControlLabel} sm={1}>Endpoint:</Col>
-            <Col sm={10}>
+            <Col sm={11}>
                 <FormControl type="text" value={this.state.endpoint} placeholder="URL of the reconciliation service endpoint" onChange={e => this.handleChange(e)}/>
                 <FormControl.Feedback />
                 <HelpBlock>{this.getMessage()}</HelpBlock>

--- a/src/TestBench.js
+++ b/src/TestBench.js
@@ -203,11 +203,11 @@ export default class TestBench extends React.Component {
        <Tabs defaultActiveKey="reconcile" animation={false} id="test-bench-tabs">
          <Tab eventKey="reconcile" title="Reconcile">
             <div className="tabContent">
-              <Col sm={3}>
+              <Col sm={5}>
                 <Form horizontal>
                     <FormGroup controlId="reconcileName">
                     <Col componentClass={ControlLabel} sm={2}>Name:</Col>
-                    <Col sm={8}>
+                    <Col sm={10}>
                         <InputGroup>
                         <FormControl
                             type="text"
@@ -220,20 +220,20 @@ export default class TestBench extends React.Component {
                     </FormGroup>
                     <FormGroup controlId="reconcileType">
                     <Col componentClass={ControlLabel} sm={2}>Type:</Col>
-                    <Col sm={8}>
+                    <Col sm={10}>
                         {this.renderTypeChoices()}
                     </Col>
                     </FormGroup>
                     {(this.hasPropertySuggest ? 
                     <FormGroup controlId="reconcileProperties">
                     <Col componentClass={ControlLabel} sm={2}>Properties:</Col>
-                    <Col sm={8}>
+                    <Col sm={10}>
                         <PropertyMapping manifest={this.props.manifest} value={this.state.reconProperties} onChange={this.onReconPropertiesChange} />
                     </Col>
                     </FormGroup> : <div/>)}
                 </Form>
               </Col>
-              <Col sm={2}>
+              <Col sm={3}>
                  <JSONTree
                         theme={theme}
                         data={this.formulateReconQuery()}
@@ -243,7 +243,7 @@ export default class TestBench extends React.Component {
                  <br />
                  <a href={this.formulateQueryUrl()} title="See query results on the service" target="_blank" rel="noopener noreferrer">View query results on the service</a>
               </Col>
-              <Col sm={2}>
+              <Col sm={4}>
                  {this.renderQueryResults()}
               </Col>
             </div>
@@ -253,19 +253,19 @@ export default class TestBench extends React.Component {
               <Form horizontal>
                 <FormGroup controlId="suggestEntityTestBench">
                     <Col componentClass={ControlLabel} sm={1}>Entity:</Col>
-                    <Col sm={3}>
+                    <Col sm={11}>
                         <ReconcileSuggest manifest={this.props.manifest} entityClass="entity" id="entity-suggest-test" />
                     </Col>
                 </FormGroup>
                 <FormGroup controlId="suggestTypeTestBench">
                     <Col componentClass={ControlLabel} sm={1}>Type:</Col>
-                    <Col sm={3}>
+                    <Col sm={11}>
                         <ReconcileSuggest manifest={this.props.manifest} entityClass="type" id="type-suggest-test" />
                     </Col>
                 </FormGroup>
                 <FormGroup controlId="suggestPropertyTestBench">
                     <Col componentClass={ControlLabel} sm={1}>Property:</Col>
-                    <Col sm={3}>
+                    <Col sm={11}>
                         <ReconcileSuggest manifest={this.props.manifest} entityClass="property" id="property-suggest-test" />
                     </Col>
                 </FormGroup>

--- a/src/TestBench.js
+++ b/src/TestBench.js
@@ -158,7 +158,7 @@ export default class TestBench extends React.Component {
          checked={current === 'custom-type'}
          onChange={this.onReconTypeChange}>
            Custom:
-           <div style={{display: 'inline-block'}}>{' '}
+           <div>
              <ReconcileSuggest
                 manifest={this.props.manifest}
                 entityClass="type"

--- a/src/style.css
+++ b/src/style.css
@@ -65,3 +65,6 @@
    color: white;
 }
 
+div .radio label {
+    width: 100%;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -24,11 +24,21 @@
 .suggestItemId {
    float: right;
    font-size: 0.8em;
+   padding-left: 5px;
+   max-width: 50%;
+   overflow: hidden;
+   text-overflow: ellipsis;
+}
+
+.suggestItemLabel {
+   max-width: 50%;
+   white-space: normal;
 }
 
 .suggestItemDescription {
    color: #888;
    font-size: 0.9em;
+   white-space: normal;
 }
 
 .dropdown-menu > li > a {


### PR DESCRIPTION
Avoid overlapping suggestion IDs and labels, and overflowing descriptions.

I've been getting these a lot when testing with https://test.lobid.org/gnd/reconcile

(GND IDs tend to be longer than e.g. Wikidata IDs)