### PR TITLE
Filter out deprecated services from the table

### DIFF
--- a/src/FeatureTable.js
+++ b/src/FeatureTable.js
@@ -36,6 +36,7 @@ export default class FeatureTable extends React.Component {
         "     pq:P2700 wd:Q64490175.\n"+
         "  OPTIONAL { ?statement (pq:P973 | pq:P2078) ?documentation }\n" +
         "  OPTIONAL { ?statement pq:P1324 ?source }\n" +
+        "  FILTER NOT EXISTS { ?statement wikibase:rank wikibase:DeprecatedRank }\n" +
         "  SERVICE wikibase:label { bd:serviceParam wikibase:language \"[AUTO_LANGUAGE],en\". }\n" +
         "}\n" +
         "ORDER BY DESC(?endpoint)\n");


### PR DESCRIPTION
Currently, the [Wikidata item about Wikidata](https://www.wikidata.org/wiki/Q2013#P6269) has two OpenRefine reconciliation services associated to it, one of which is deprecated. I think the SPARQL query should filter out deprecated services so that they do not show up in the table.