### PR TITLE
Display single-level `broader` types as breadcrumb

### DIFF
--- a/src/ReconcileSuggest.js
+++ b/src/ReconcileSuggest.js
@@ -84,7 +84,7 @@ export default class ReconcileSuggest extends React.Component {
            renderMenuItemChildren={(option, props, index) => 
               <>
                  <span className="suggestItemId">{option.id}</span>
-                 {option.broader && <span className="suggestItemId">{option.broader} &gt; </span>}
+                 {Array.isArray(option.broader) && option.broader.length && <span className="suggestItemId">{option.broader.join(', ')} &gt; </span>}
                  <span className="suggestItemLabel">{option.name}</span><br />
                  <span className="suggestItemDescription">{option.description}</span>
               </>

--- a/src/ReconcileSuggest.js
+++ b/src/ReconcileSuggest.js
@@ -84,6 +84,7 @@ export default class ReconcileSuggest extends React.Component {
            renderMenuItemChildren={(option, props, index) => 
               <>
                  <span className="suggestItemId">{option.id}</span>
+                 {option.broader && <span className="suggestItemId">{option.broader} &gt; </span>}
                  <span className="suggestItemLabel">{option.name}</span><br />
                  <span className="suggestItemDescription">{option.description}</span>
               </>

--- a/src/ReconcileSuggest.js
+++ b/src/ReconcileSuggest.js
@@ -84,7 +84,7 @@ export default class ReconcileSuggest extends React.Component {
            renderMenuItemChildren={(option, props, index) => 
               <>
                  <span className="suggestItemId">{option.id}</span>
-                 {Array.isArray(option.broader) && option.broader.length && <span className="suggestItemId">{option.broader.join(', ')} &gt; </span>}
+                 {Array.isArray(option.broader) && option.broader.length && <span className="suggestItemId">{option.broader.map(e => e.id).join(', ')} &gt; </span>}
                  <span className="suggestItemLabel">{option.name}</span><br />
                  <span className="suggestItemDescription">{option.description}</span>
               </>

--- a/src/TestBench.js
+++ b/src/TestBench.js
@@ -213,7 +213,7 @@ export default class TestBench extends React.Component {
           checked={current === t.id}
           onChange={this.onReconTypeChange}>
         {t.name}<br />
-        {Array.isArray(t.broader) && t.broader.length && <span className="reconTypeId">{t.broader.join(', ')} &gt; </span>}<span className="reconTypeId">{t.id}</span>
+        {Array.isArray(t.broader) && t.broader.length && <span className="reconTypeId">{t.broader.map(e => e.id).join(', ')} &gt; </span>}<span className="reconTypeId">{t.id}</span>
       </Radio>
     );
     if (this.hasTypeSuggest) {

--- a/src/TestBench.js
+++ b/src/TestBench.js
@@ -213,7 +213,7 @@ export default class TestBench extends React.Component {
           checked={current === t.id}
           onChange={this.onReconTypeChange}>
         {t.name}<br />
-        {t.broader && <span className="reconTypeId">{t.broader} &gt; </span>}<span className="reconTypeId">{t.id}</span>
+        {Array.isArray(t.broader) && t.broader.length && <span className="reconTypeId">{t.broader.join(', ')} &gt; </span>}<span className="reconTypeId">{t.id}</span>
       </Radio>
     );
     if (this.hasTypeSuggest) {

--- a/src/TestBench.js
+++ b/src/TestBench.js
@@ -212,7 +212,8 @@ export default class TestBench extends React.Component {
           value={t.id}
           checked={current === t.id}
           onChange={this.onReconTypeChange}>
-        {t.name}<br /><span className="reconTypeId">{t.id}</span>
+        {t.name}<br />
+        {t.broader && <span className="reconTypeId">{t.broader} &gt; </span>}<span className="reconTypeId">{t.id}</span>
       </Radio>
     );
     if (this.hasTypeSuggest) {


### PR DESCRIPTION
Basic test case for using `broader` type IDs (see https://github.com/reconciliation-api/specs/issues/68 & https://github.com/reconciliation-api/specs/pull/73).

Shows single-level broader type before `>` for default and suggested types.

Can be tested with https://test.lobid.org/gnd/reconcile (see https://github.com/hbz/lobid-gnd/commit/5c8d0a8a2049b06dee23827e6e33cf20065b3f1f):

![broader types](https://user-images.githubusercontent.com/128229/134150232-025ca8b9-0e61-451e-b384-7f73e5bdd2d2.png)

