### PR TITLE
Fixed css for link in matched candidates

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -71,7 +71,7 @@
 
 /* Candidates */
 
-.active > .list-group-item-text > a {
+.list-group-item.active a {
    color: white;
 }
 


### PR DESCRIPTION
The CSS to turn the link color white was not selecting the correct classes.  

closes #40